### PR TITLE
fix: serve /talks/<slug> as a clean URL (drop /index.html)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,31 @@ Path alias: `@/` → `src/frontend/`. TypeScript config restricts compilation to
 
 ## Conventions
 
+### Dev/prod parity
+
+Every change must work the same way in both **local dev** (`npm run dev`,
+served by Vite) and **production** (deployed to Vercel). The two environments
+are independent: Vite's dev server does **not** read `vercel.json`, so
+anything configured there — redirects, rewrites, headers, trailing-slash
+behaviour — has no effect locally unless explicitly mirrored.
+
+When you add or change a Vercel rule, add a matching dev-server middleware in
+`vite.config.ts`. The `staticTalksDevServer` plugin is an example: it
+replicates the `/talks/:talk` → `/talks/:talk/` 308 redirect from
+`vercel.json` so talks render the same way locally as in prod.
+
+When verifying a change, exercise both:
+
+- `npm run dev` (Vite) — `curl` or browser the affected paths.
+- A Vercel preview deploy, or at minimum `npm run build` + an inspection of
+  `dist/` against the rules in `vercel.json`.
+
+If you can't verify one side, say so explicitly rather than assuming parity.
+
 ### Blog posts
 - File name: `src/frontend/posts/YYYY-MM-DD-kebab-slug.md`. The date prefix is
-  load-bearing — it drives ordering (`generate_post_names.py`) and Atom feed
-  dates (`generate_rss.py`).
+  load-bearing — it drives ordering and Atom feed dates
+  (`src/backend/generate_rss.py`).
 - Frontmatter must start with `---` on line 1 and contain at least `title`. Use
   `meta:` (preferred) or `description:` for the feed summary, and `tags:` for
   comma-separated tags.
@@ -77,6 +98,15 @@ Path alias: `@/` → `src/frontend/`. TypeScript config restricts compilation to
   `TalkBox.vue` before adding fields.
 - `talks.yaml` items have a `kind` of `talk`, `podcast` or `webinar`, and use
   either `url`, `embed` (iframe src), with optional `embedRatio` / `embedHeight`.
+
+### Standalone HTML pages (talks)
+- Self-contained decks live in `public/talks/<slug>/index.html` plus
+  `public/talks/<slug>/media/...`. They reference media with relative paths,
+  so they must be served with the URL ending in `/`. The `/talks/<slug>` →
+  `/talks/<slug>/` 308 redirect is configured in both `vercel.json` and the
+  `staticTalksDevServer` dev middleware.
+- Link to them from `talks.yaml` as `/talks/<slug>/` (with trailing slash) to
+  skip the redirect hop.
 
 ### Routing
 - All "real" pages have `meta.showMenus: true`. Standalone embed pages
@@ -98,9 +128,10 @@ Path alias: `@/` → `src/frontend/`. TypeScript config restricts compilation to
 
 - **`generate_rss.py` writes `public/atom.xml` and exits** — committing and
   pushing the file is the `make deploy` target's job.
-- **SPA + trailing slash**: `vercel.json` sets `trailingSlash: false` and
-  rewrites everything to `index.html`. Don't add server-side routes — there's
-  no server.
+- **SPA fallback**: `vercel.json` rewrites everything that isn't a static
+  file to `/index.html` so Vue Router can handle it. There's no server; don't
+  add server-side routes. Vue Router 4 matches non-strict by default, so
+  `/posts` and `/posts/` both resolve to the same route.
 - **MathJax 3** config lives inline in `index.html`. Inline math: `$...$` or
   `\(...\)`; display: `$$...$$` or `\[...\]`. Re-typesetting after route
   navigation is triggered in `PostView.vue` via `MathJax.typesetPromise()`.

--- a/src/frontend/talks.yaml
+++ b/src/frontend/talks.yaml
@@ -1,6 +1,6 @@
 - name: Skal vi nu skifte AI model igen?
   description: Driving AI conference 2026 — keeping up with the model treadmill.
-  url: /talks/driving-ai/index.html
+  url: /talks/driving-ai/
   kind: talk
 
 - name: Generativ AI i praksis

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,10 @@
 {
+  "redirects": [
+    { "source": "/talks/:talk", "destination": "/talks/:talk/", "permanent": true }
+  ],
   "rewrites": [
     { "source": "/:path*", "destination": "/index.html" }
   ],
-  "trailingSlash" : false,
   "headers": [
     {
       "source": "/atom.xml",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,9 +24,10 @@ const dynamicRoutes = [
   ...postNames.map((name) => `/posts/${name}`),
 ];
 
-// Dev-only: mirror Vercel's behaviour for /talks/<slug>(/). Vite's dev
-// server doesn't auto-serve directory index.html files, so these paths
-// would otherwise fall through to the SPA shell and render blank.
+// Dev-only: mirror Vercel's behaviour for /talks/<slug> in vercel.json.
+//   /talks/<slug>   -> 308 redirect to /talks/<slug>/
+//   /talks/<slug>/  -> serve public/talks/<slug>/index.html
+// Without this, Vite would fall through to the SPA shell and render blank.
 function staticTalksDevServer(): Plugin {
   return {
     name: "serve-talks-index",
@@ -35,15 +36,21 @@ function staticTalksDevServer(): Plugin {
       const publicDir = resolve(
         fileURLToPath(new URL("./public", import.meta.url)),
       );
-      server.middlewares.use((req, _res, next) => {
-        const url = req.url?.split("?")[0] ?? "";
-        const match = url.match(/^\/talks\/([^/]+)\/?$/);
-        if (match) {
-          const indexPath = resolve(publicDir, "talks", match[1], "index.html");
-          if (existsSync(indexPath)) {
-            req.url = `/talks/${match[1]}/index.html`;
-          }
+      server.middlewares.use((req, res, next) => {
+        const [pathname, query] = (req.url ?? "").split("?");
+        const match = pathname.match(/^\/talks\/([^/]+)(\/?)$/);
+        if (!match) return next();
+        const slug = match[1];
+        const indexPath = resolve(publicDir, "talks", slug, "index.html");
+        if (!existsSync(indexPath)) return next();
+        if (match[2] === "") {
+          const target = `/talks/${slug}/${query ? `?${query}` : ""}`;
+          res.statusCode = 308;
+          res.setHeader("Location", target);
+          res.end();
+          return;
         }
+        req.url = `/talks/${slug}/index.html${query ? `?${query}` : ""}`;
         next();
       });
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
 import { fileURLToPath, URL } from "node:url";
-import { readdirSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import Vue from "@vitejs/plugin-vue";
 import Markdown from "vite-plugin-md";
 import MarkdownItAnchor from "markdown-it-anchor";
@@ -24,8 +24,35 @@ const dynamicRoutes = [
   ...postNames.map((name) => `/posts/${name}`),
 ];
 
+// Dev-only: mirror Vercel's behaviour for /talks/<slug>(/). Vite's dev
+// server doesn't auto-serve directory index.html files, so these paths
+// would otherwise fall through to the SPA shell and render blank.
+function staticTalksDevServer(): Plugin {
+  return {
+    name: "serve-talks-index",
+    apply: "serve",
+    configureServer(server) {
+      const publicDir = resolve(
+        fileURLToPath(new URL("./public", import.meta.url)),
+      );
+      server.middlewares.use((req, _res, next) => {
+        const url = req.url?.split("?")[0] ?? "";
+        const match = url.match(/^\/talks\/([^/]+)\/?$/);
+        if (match) {
+          const indexPath = resolve(publicDir, "talks", match[1], "index.html");
+          if (existsSync(indexPath)) {
+            req.url = `/talks/${match[1]}/index.html`;
+          }
+        }
+        next();
+      });
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [
+    staticTalksDevServer(),
     Vue({
       include: [/\.vue$/, /\.md$/],
     }),


### PR DESCRIPTION
## Summary
Make `https://www.saattrupdan.com/talks/driving-ai` work directly (no `/index.html` suffix needed) and ensure dev mirrors prod.

### Production (Vercel)
- New 308 redirect: `/talks/:talk` → `/talks/:talk/`. With the URL ending in `/`, the static `index.html` is served by Vercel's directory-index handling and the deck's relative `media/...` paths resolve correctly.
- Removed `"trailingSlash": false` from `vercel.json` — it was actively stripping the trailing slash and undoing the redirect. Vue Router 4 matches non-strict by default, so SPA routes like `/posts` work whether the URL ends with `/` or not.
- Updated `talks.yaml` to link to `/talks/driving-ai/` directly, skipping the redirect hop.

### Dev (Vite)
- Vite's dev server doesn't read `vercel.json` or auto-serve directory `index.html` files, so without parity the talk just renders blank locally. Added a small `staticTalksDevServer` plugin in `vite.config.ts` that mirrors the prod behaviour exactly:
  - `/talks/<slug>` → 308 to `/talks/<slug>/`
  - `/talks/<slug>/` → serves `public/talks/<slug>/index.html` internally
- Works generically for any future talk under `public/talks/<slug>/`.

### Docs
- Added an explicit **Dev/prod parity** convention to `AGENTS.md`: anything configured in `vercel.json` must have a matching dev-server middleware in `vite.config.ts`, and changes must be verified in both environments. Also added a short section on standalone HTML pages (talks).
- Refreshed the "SPA + trailing slash" bullet to match the new config.

## Test plan
- [x] `npm run build` passes.
- [x] `npm run dev`: `curl /talks/driving-ai` returns 308 → `/talks/driving-ai/`; `curl /talks/driving-ai/` returns the 91 KB deck; `/posts` still hits the SPA.
- [x] Vercel preview deploy: confirm `/talks/driving-ai` redirects to `/talks/driving-ai/` and the deck (including media) renders end-to-end.
- [x] Confirm SPA routes (`/`, `/posts`, `/posts/<slug>`, `/papers`, `/projects`, `/talks`) still load on the preview after `trailingSlash: false` removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)