### PR TITLE
feat: per-route head metadata and JSON-LD (SEO phase 2)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -18,12 +18,13 @@ Tracking checklist for the multi-phase SEO/AIO overhaul. Each phase ships as its
 
 ## Phase 2 — Head metadata per route
 
-- [ ] Global head defaults in `App.vue` via `useHead` (author, default OG, canonical, atom alternate)
-- [ ] Per-view `useHead` calls (`AboutView`, `BlogView`, `PapersView`, `ProjectsView`, `TalksView`, `PostView`)
-- [ ] JSON-LD: `Person` schema on `/`
-- [ ] JSON-LD: `BlogPosting` on each post
-- [ ] JSON-LD: `ScholarlyArticle` array on `/papers`
-- [ ] OG / Twitter Card tags per page
+- [x] Global head defaults in `App.vue` via `useHead` (author, default OG, canonical, atom alternate)
+- [x] Per-view `useHead` calls (`AboutView`, `BlogView`, `PapersView`, `ProjectsView`, `TalksView`, `PostView`)
+- [x] JSON-LD: `Person` schema on `/`
+- [x] JSON-LD: `BlogPosting` on each post
+- [x] JSON-LD: `ScholarlyArticle` array on `/papers`
+- [x] OG / Twitter Card tags per page
+- [x] Remove redundant client-side title/meta mutation in router
 
 ## Phase 3 — URL hygiene
 

--- a/index.html
+++ b/index.html
@@ -3,8 +3,6 @@
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
-    <title>Dan Saattrup Smart's Site</title>
-    <meta name="description" content="This is the website of Dan Saattrup Smart.">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- MathJax 3 -->

--- a/src/frontend/App.vue
+++ b/src/frontend/App.vue
@@ -3,13 +3,36 @@ import Header from "@/components/TheHeader.vue";
 import Footer from "@/components/TheFooter.vue";
 import { useRoute } from "vue-router";
 import { computed } from "vue";
+import { useHead } from "@unhead/vue";
+import { SITE_NAME, SITE_URL, AUTHOR_NAME, absoluteUrl } from "@/seo/site";
 
 const route = useRoute();
-// Only force a remount when switching between individual blog posts (same
-// route component, different `id`). Other navigations reuse components.
 const viewKey = computed(() =>
   route.name === "Post" ? `post:${route.params.id}` : (route.name as string),
 );
+
+const canonicalUrl = computed(() => absoluteUrl(route.path));
+
+useHead({
+  titleTemplate: (title?: string) =>
+    title && title !== SITE_NAME ? `${title} | ${SITE_NAME}` : SITE_NAME,
+  meta: [
+    { name: "author", content: AUTHOR_NAME },
+    { property: "og:site_name", content: SITE_NAME },
+    { property: "og:type", content: "website" },
+    { property: "og:url", content: canonicalUrl },
+    { name: "twitter:card", content: "summary_large_image" },
+  ],
+  link: [
+    { rel: "canonical", href: canonicalUrl },
+    {
+      rel: "alternate",
+      type: "application/atom+xml",
+      title: `${SITE_NAME} — Blog`,
+      href: `${SITE_URL}/atom.xml`,
+    },
+  ],
+});
 </script>
 
 <template>

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -3,7 +3,6 @@ import { createPinia } from "pinia";
 
 import App from "@/App.vue";
 import { routes } from "@/router/routes";
-import { setupRouterHooks } from "@/router";
 import { vClickOutside } from "@/directives";
 
 import "./assets/main.css";
@@ -26,9 +25,8 @@ export const createApp = ViteSSG(
       });
     },
   },
-  ({ app, router, isClient }) => {
+  ({ app }) => {
     app.use(createPinia());
     app.directive("click-outside", vClickOutside);
-    setupRouterHooks(router, isClient);
   },
 );

--- a/src/frontend/router/index.ts
+++ b/src/frontend/router/index.ts
@@ -1,7 +1,0 @@
-import type { Router } from "vue-router";
-
-// Placeholder kept so main.ts's import is stable across phases.
-// Per-route <head> updates are now driven by useHead() in each view.
-export function setupRouterHooks(_router: Router, _isClient: boolean) {
-  // intentionally empty
-}

--- a/src/frontend/router/index.ts
+++ b/src/frontend/router/index.ts
@@ -1,39 +1,7 @@
 import type { Router } from "vue-router";
 
-// Per-route document.title / meta description updates. vite-ssg bakes the
-// initial values into the prerendered HTML; this hook keeps them in sync
-// during client-side navigation. Phase 2 will replace it with per-view
-// useHead() calls.
-export function setupRouterHooks(router: Router, isClient: boolean) {
-  if (!isClient) return;
-
-  router.beforeEach((to, _from, next) => {
-    const id = to.params.id;
-    if (id) {
-      import(`@/posts/${id}.md`).then((module) => {
-        const title = module.frontmatter["title"];
-        const description = module.frontmatter["meta"];
-        if (title) document.title = title;
-        const metaDescription = document.querySelector(
-          'meta[name="description"]',
-        );
-        if (metaDescription && description) {
-          metaDescription.setAttribute("content", description);
-        }
-      });
-    } else {
-      const title = to.meta.title as string | undefined;
-      const description = to.meta.description as string | undefined;
-      if (title) document.title = title;
-      if (description) {
-        const metaDescription = document.querySelector(
-          'meta[name="description"]',
-        );
-        if (metaDescription) {
-          metaDescription.setAttribute("content", description);
-        }
-      }
-    }
-    next();
-  });
+// Placeholder kept so main.ts's import is stable across phases.
+// Per-route <head> updates are now driven by useHead() in each view.
+export function setupRouterHooks(_router: Router, _isClient: boolean) {
+  // intentionally empty
 }

--- a/src/frontend/seo/site.ts
+++ b/src/frontend/seo/site.ts
@@ -1,0 +1,17 @@
+export const SITE_URL = "https://saattrupdan.com";
+export const SITE_NAME = "Dan Saattrup Smart";
+export const AUTHOR_NAME = "Dan Saattrup Smart";
+export const AUTHOR_JOB_TITLE = "Principal AI Specialist";
+export const AUTHOR_AFFILIATION = "Alexandra Institute";
+
+export const SAME_AS = [
+  "https://github.com/saattrupdan",
+  "https://www.linkedin.com/in/saattrupdan/",
+  "https://scholar.google.com/citations?user=aNojQDEAAAAJ&hl=en",
+  "https://orcid.org/0000-0001-9227-1470",
+];
+
+export function absoluteUrl(path: string): string {
+  if (path.startsWith("http")) return path;
+  return `${SITE_URL}${path.startsWith("/") ? path : `/${path}`}`;
+}

--- a/src/frontend/views/AboutView.vue
+++ b/src/frontend/views/AboutView.vue
@@ -2,7 +2,50 @@
 import Greeting from "@/components/TheGreeting.vue";
 import Description from "@/about.md";
 import photoUrl from "@/assets/img/itu-photo.webp";
+import { useHead } from "@unhead/vue";
+import {
+  AUTHOR_AFFILIATION,
+  AUTHOR_JOB_TITLE,
+  AUTHOR_NAME,
+  SAME_AS,
+  SITE_URL,
+} from "@/seo/site";
+
 const wrappedPhotoUrl = `url(${photoUrl})`;
+
+const description =
+  "Dan Saattrup Smart is a Principal AI Specialist at the Alexandra Institute with a PhD in mathematics and a postdoc in machine learning, working on research and applied AI for Danish companies.";
+
+const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: AUTHOR_NAME,
+  jobTitle: AUTHOR_JOB_TITLE,
+  affiliation: {
+    "@type": "Organization",
+    name: AUTHOR_AFFILIATION,
+  },
+  url: SITE_URL,
+  description,
+  sameAs: SAME_AS,
+};
+
+useHead({
+  title: AUTHOR_NAME,
+  meta: [
+    { name: "description", content: description },
+    { property: "og:title", content: AUTHOR_NAME },
+    { property: "og:description", content: description },
+    { name: "twitter:title", content: AUTHOR_NAME },
+    { name: "twitter:description", content: description },
+  ],
+  script: [
+    {
+      type: "application/ld+json",
+      innerHTML: JSON.stringify(personJsonLd),
+    },
+  ],
+});
 </script>
 
 <template>

--- a/src/frontend/views/AboutView.vue
+++ b/src/frontend/views/AboutView.vue
@@ -22,7 +22,7 @@ const personJsonLd = {
   name: AUTHOR_NAME,
   jobTitle: AUTHOR_JOB_TITLE,
   affiliation: {
-    "@type": "Organization",
+    "@type": "ResearchOrganization",
     name: AUTHOR_AFFILIATION,
   },
   url: SITE_URL,

--- a/src/frontend/views/BlogView.vue
+++ b/src/frontend/views/BlogView.vue
@@ -2,6 +2,21 @@
 import PostSnippet from "@/components/PostSnippet.vue";
 import postNames from "@/posts/postNames.ts";
 import { ref, onMounted, onUnmounted, type Ref } from "vue";
+import { useHead } from "@unhead/vue";
+
+const title = "Blog";
+const description =
+  "Blog posts by Dan Saattrup Smart on machine learning, AI, mathematics, set theory, and software engineering.";
+useHead({
+  title,
+  meta: [
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description },
+  ],
+});
 
 const PAGE_SIZE = 5;
 const visibleCount = ref(Math.min(PAGE_SIZE, postNames.length));

--- a/src/frontend/views/PapersView.vue
+++ b/src/frontend/views/PapersView.vue
@@ -1,9 +1,66 @@
 <script lang="ts" setup>
 import Abstract from "@/components/PaperAbstract.vue";
 import papers from "@/papers.yaml";
+import { useHead } from "@unhead/vue";
+import { AUTHOR_NAME } from "@/seo/site";
 
-// Store the list of years, from newest to oldest
+interface Paper {
+  title: string;
+  url: string;
+  authors: string[];
+  venue: string;
+  abstract?: string;
+}
+
 const years = Object.keys(papers).reverse();
+
+const title = "Papers";
+const description =
+  "Peer-reviewed research papers by Dan Saattrup Smart on natural language processing, large language model evaluation, and applied machine learning.";
+
+const itemList = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: `Research papers by ${AUTHOR_NAME}`,
+  itemListElement: years.flatMap((year) =>
+    ((papers as Record<string, Paper[]>)[year] ?? []).map(
+      (paper: Paper, index: number) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        item: {
+          "@type": "ScholarlyArticle",
+          headline: paper.title.trim(),
+          name: paper.title.trim(),
+          url: paper.url,
+          datePublished: year,
+          author: paper.authors.map((name) => ({
+            "@type": "Person",
+            name,
+          })),
+          publisher: paper.venue,
+          abstract: paper.abstract?.trim(),
+        },
+      }),
+    ),
+  ),
+};
+
+useHead({
+  title,
+  meta: [
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description },
+  ],
+  script: [
+    {
+      type: "application/ld+json",
+      innerHTML: JSON.stringify(itemList),
+    },
+  ],
+});
 </script>
 
 <template>

--- a/src/frontend/views/PostView.vue
+++ b/src/frontend/views/PostView.vue
@@ -2,6 +2,8 @@
 import { computed, defineAsyncComponent, ref } from "vue";
 import NotFound from "@/components/NotFound.vue";
 import { postMeta } from "@/posts/postMeta";
+import { useHead } from "@unhead/vue";
+import { AUTHOR_NAME, SITE_URL, absoluteUrl } from "@/seo/site";
 
 const { id } = defineProps({
   id: { type: String, required: true },
@@ -21,6 +23,62 @@ const PostContent = defineAsyncComponent(() =>
 );
 
 const showDate = computed(() => !notFound.value);
+
+if (meta) {
+  const isoDate = id.split("-").slice(0, 3).join("-");
+  const description =
+    meta.description || `${meta.title} — a blog post by ${AUTHOR_NAME}.`;
+  const postUrl = absoluteUrl(`/posts/${id}`);
+  const fullTitle = meta.subtitle
+    ? `${meta.title}: ${meta.subtitle}`
+    : meta.title;
+
+  const blogPostingJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: fullTitle,
+    description,
+    datePublished: isoDate,
+    dateModified: isoDate,
+    author: {
+      "@type": "Person",
+      name: AUTHOR_NAME,
+      url: SITE_URL,
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": postUrl,
+    },
+    keywords: meta.tags,
+  };
+
+  useHead({
+    title: fullTitle,
+    meta: [
+      { name: "description", content: description },
+      { property: "og:type", content: "article" },
+      { property: "og:title", content: fullTitle },
+      { property: "og:description", content: description },
+      { property: "article:author", content: AUTHOR_NAME },
+      { property: "article:published_time", content: isoDate },
+      ...(meta.tags
+        ? meta.tags
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean)
+            .map((tag) => ({ property: "article:tag", content: tag }))
+        : []),
+      { name: "twitter:title", content: fullTitle },
+      { name: "twitter:description", content: description },
+    ],
+    script: [
+      {
+        type: "application/ld+json",
+        innerHTML: JSON.stringify(blogPostingJsonLd),
+      },
+    ],
+  });
+}
 
 // Client-only enhancements: syntax highlighting and MathJax typesetting.
 async function enhance() {

--- a/src/frontend/views/ProjectsView.vue
+++ b/src/frontend/views/ProjectsView.vue
@@ -1,6 +1,21 @@
 <script lang="ts" setup>
 import ProjectBox from "@/components/ProjectBox.vue";
 import projects from "@/projects.yaml";
+import { useHead } from "@unhead/vue";
+
+const title = "Projects";
+const description =
+  "Open-source projects by Dan Saattrup Smart, spanning machine learning libraries, evaluation benchmarks, and developer tools.";
+useHead({
+  title,
+  meta: [
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description },
+  ],
+});
 </script>
 
 <template>

--- a/src/frontend/views/TalksView.vue
+++ b/src/frontend/views/TalksView.vue
@@ -2,6 +2,21 @@
 import { ref } from "vue";
 import TalkBox from "@/components/TalkBox.vue";
 import talks from "@/talks.yaml";
+import { useHead } from "@unhead/vue";
+
+const title = "Talks, Podcasts & Webinars";
+const description =
+  "A collection of talks, podcasts, and webinars that Dan Saattrup Smart has been a part of, covering AI, machine learning, and applied research.";
+useHead({
+  title,
+  meta: [
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description },
+  ],
+});
 
 interface Talk {
   name: string;


### PR DESCRIPTION
Second PR in the SEO/AIO overhaul tracked in [`PLAN.md`](./PLAN.md).

## Summary
- Adds `@unhead/vue`'s `useHead` (bundled with vite-ssg, no new dep) to drive per-route `<title>`, `<meta description>`, Open Graph, Twitter Card, and canonical link tags.
- Global defaults in `App.vue`: title template `"<page> | Dan Saattrup Smart"`, author meta, `og:site_name`, `og:type`, `og:url`, canonical link (route-driven), atom-feed alternate link.
- Per-view `useHead` in `AboutView`, `BlogView`, `PapersView`, `ProjectsView`, `TalksView`, `PostView` — each sets its own title, description, and OG/Twitter content.
- **JSON-LD structured data** (the AI-search win):
  - `Person` on `/` with `sameAs` linking GitHub, LinkedIn, Google Scholar, ORCID.
  - `BlogPosting` on every post (`headline`, `description`, `datePublished`, `author`, `mainEntityOfPage`, `keywords`).
  - `ItemList` of `ScholarlyArticle` on `/papers` with authors, venue, abstract, year.
- Drops the now-redundant `document.title` / `meta[name=description]` mutation in `router/index.ts` (replaced by reactive `useHead`).
- Removes the hardcoded `<title>` and `<meta description>` from `index.html` so they're driven entirely by useHead.
- New `src/frontend/seo/site.ts` centralising site constants (URL, author, `sameAs` URLs).

## Verified in build output
- `dist/index.html` → `<title>Dan Saattrup Smart</title>` + Person JSON-LD + canonical + OG.
- `dist/posts/2026-03-08-…/index.html` → `<title>Local AI Coding Assistant in Neovim in 2026 v2 | Dan Saattrup Smart</title>` + post description + `og:type=article` + `article:published_time` + BlogPosting JSON-LD.
- `dist/papers/index.html` → ItemList of ScholarlyArticle entries with full author/venue/abstract data.

## Test plan
- [x] `npm run build` succeeds; head tags inspected in dist.
- [x] Vercel preview: paste a post URL into LinkedIn/Slack and confirm the rich preview shows the post title + description.
- [ ] Validate JSON-LD with Google's [Rich Results Test](https://search.google.com/test/rich-results) on `/`, a post, and `/papers`.
- [x] Client-side navigation: confirm title/meta update correctly when navigating between views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)