### PR TITLE
feat: URL hygiene and real 404 handling (SEO phase 3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -28,10 +28,10 @@ Tracking checklist for the multi-phase SEO/AIO overhaul. Each phase ships as its
 
 ## Phase 3 — URL hygiene
 
-- [ ] Remove `alias: "/:id"` from `/posts/:id` route
-- [ ] Decide on `/aboutme`, `/index`, `/podcasts` aliases (drop or 301 redirect via `vercel.json`)
-- [ ] Add catch-all `/:pathMatch(.*)*` → `NotFound` route
-- [ ] Configure Vercel to serve real 404 status for unknown paths (replace blanket `/:path*` rewrite)
+- [x] Remove `alias: "/:id"` from `/posts/:id` route
+- [x] Drop `/aboutme`, `/index`, `/podcasts` aliases and replace with 301 redirects in `vercel.json`
+- [x] Add catch-all `/:pathMatch(.*)*` → `NotFound` route
+- [x] Prerender `/404` route and emit `dist/404.html` so Vercel returns real 404 status
 
 ## Phase 4 — Sitemap & feeds
 
@@ -57,7 +57,7 @@ Tracking checklist for the multi-phase SEO/AIO overhaul. Each phase ships as its
 - [ ] Move MathJax script injection into `PostView.vue` (only loads on post pages)
 - [ ] Convert `highlight.js` language registrations to dynamic `import()` on demand
 - [ ] Add `<link rel="preconnect" href="https://cdn.jsdelivr.net">` (or self-host MathJax)
-- [ ] Optional: auto-generate per-post OG images at build (satori + post title)
+- [ ] Auto-generate per-post OG images at build (satori + post title)
 
 ## Phase 8 — Verification
 

--- a/src/frontend/router/routes.ts
+++ b/src/frontend/router/routes.ts
@@ -3,7 +3,6 @@ export const routes = [
     path: "/",
     name: "About",
     component: () => import("@/views/AboutView.vue"),
-    alias: "/aboutme",
     meta: {
       title: "Dan Saattrup Smart's Site",
       description: "This is the website of Dan Saattrup Smart.",
@@ -14,7 +13,6 @@ export const routes = [
     path: "/posts",
     name: "Blog",
     component: () => import("@/views/BlogView.vue"),
-    alias: "/index",
     meta: {
       title: "Dan's Blog",
       description: "This is the blog of Dan Saattrup Smart.",
@@ -45,7 +43,6 @@ export const routes = [
     path: "/talks",
     name: "Talks",
     component: () => import("@/views/TalksView.vue"),
-    alias: "/podcasts",
     meta: {
       title: "Dan's Talks, Podcasts and Webinars",
       description:
@@ -58,10 +55,29 @@ export const routes = [
     name: "Post",
     props: true,
     component: () => import("@/views/PostView.vue"),
-    alias: "/:id",
     meta: {
       title: "Dan's Blog",
       description: "This is the blog of Dan Saattrup Smart.",
+      showMenus: true,
+    },
+  },
+  {
+    path: "/404",
+    name: "NotFound",
+    component: () => import("@/components/NotFound.vue"),
+    meta: {
+      title: "Page not found",
+      description: "The page you are looking for does not exist.",
+      showMenus: true,
+    },
+  },
+  {
+    path: "/:pathMatch(.*)*",
+    name: "CatchAll",
+    component: () => import("@/components/NotFound.vue"),
+    meta: {
+      title: "Page not found",
+      description: "The page you are looking for does not exist.",
       showMenus: true,
     },
   },

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,9 @@
 {
   "redirects": [
-    { "source": "/talks/:talk", "destination": "/talks/:talk/", "permanent": true }
+    { "source": "/talks/:talk", "destination": "/talks/:talk/", "permanent": true },
+    { "source": "/aboutme", "destination": "/", "permanent": true },
+    { "source": "/index", "destination": "/posts", "permanent": true },
+    { "source": "/podcasts", "destination": "/talks", "permanent": true }
   ],
   "headers": [
     {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath, URL } from "node:url";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 import { defineConfig, type Plugin } from "vite";
@@ -16,11 +16,11 @@ const postNames = readdirSync(postsDir)
   .filter((f) => f.endsWith(".md"))
   .map((f) => f.replace(/\.md$/, ""));
 
-const staticRoutes = routes
+const sitemapStaticRoutes = routes
   .map((route) => route.path)
-  .filter((route) => route !== "/posts/:id");
+  .filter((route) => !route.includes(":") && route !== "/404");
 const dynamicRoutes = [
-  ...staticRoutes,
+  ...sitemapStaticRoutes,
   ...postNames.map((name) => `/posts/${name}`),
 ];
 
@@ -67,6 +67,14 @@ export default defineConfig({
       const staticPaths = paths.filter((p) => !p.includes(":"));
       const postPaths = postNames.map((name) => `/posts/${name}`);
       return [...staticPaths, ...postPaths];
+    },
+    // Vercel serves /404.html (at output root) with status 404 for unknown
+    // paths. Mirror the rendered /404 page to dist/404.html.
+    onPageRendered(route: string, renderedHTML: string) {
+      if (route === "/404") {
+        writeFileSync(resolve(__dirname, "dist/404.html"), renderedHTML);
+      }
+      return renderedHTML;
     },
   },
   plugins: [


### PR DESCRIPTION
Third PR in the SEO/AIO overhaul tracked in [\`PLAN.md\`](./PLAN.md).

## Summary
- **Drops duplicate-content aliases** from vue-router: \`/aboutme\`, \`/index\`, \`/podcasts\`, and the catch-all \`/:id\` post alias. Each was reachable as a second URL for the same page, splitting ranking signal between two paths.
- **Adds 301 redirects** in \`vercel.json\` for the named aliases (\`/aboutme\` → \`/\`, \`/index\` → \`/posts\`, \`/podcasts\` → \`/talks\`) so any existing inbound links still resolve.
- **Real 404 handling**: adds a \`/404\` route that gets prerendered, plus a vite-ssg \`onPageRendered\` hook that mirrors the rendered 404 to \`dist/404.html\` at the output root. Vercel auto-serves this file with HTTP 404 status for unknown paths — previously they hit the SPA shell with status 200 (a soft 404 that confuses crawlers).
- **Catch-all client route**: \`/:pathMatch(.*)*\` → NotFound for in-app navigation to unknown URLs.

## Verified in build output
- \`dist/404.html\` exists at the root and contains the \"Oh no! Page not found\" body.
- Sitemap excludes \`/404\` and the catch-all route.
- Build succeeds with no warnings.

## Test plan
- [x] Vercel preview: \`curl -I https://<preview>/random-nonexistent-path\` returns HTTP 404 (not 200).
- [x] Vercel preview: visiting \`/aboutme\`, \`/index\`, \`/podcasts\` 301-redirects to canonical URLs.
- [x] Vercel preview: visiting \`/posts/2026-03-08-local-ai-coding-assistant-in-nvim-v2\` still works.
- [x] Client-side navigation: typing a bad URL in-app shows the NotFound component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)