### PR TITLE
feat: crawler signals via robots.txt and llms.txt (SEO phase 5)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -42,8 +42,8 @@ Tracking checklist for the multi-phase SEO/AIO overhaul. Each phase ships as its
 
 ## Phase 5 — Crawler signals
 
-- [ ] Update `robots.txt` with explicit `Allow` for GPTBot, ClaudeBot, PerplexityBot, OAI-SearchBot, Google-Extended
-- [ ] Add `public/llms.txt` (bio + links to posts, papers, projects, ORCID/Scholar)
+- [x] Update `robots.txt` with explicit `Allow` for GPTBot, ClaudeBot, PerplexityBot, OAI-SearchBot, Google-Extended
+- [x] Add `public/llms.txt` (bio + links to posts, papers, projects, ORCID/Scholar)
 
 ## Phase 6 — Content semantics
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,23 @@
+# Dan Saattrup Smart
+
+> Principal AI Specialist at the Alexandra Institute (Denmark) with a PhD in mathematics and a postdoc in machine learning. Research and writing on low-resource natural language processing (especially Scandinavian languages), bias in language models, uncertainty estimation, graph machine learning, and applied AI.
+
+This site hosts blog posts, research papers, open-source projects, and talks. Most blog posts are technical write-ups on machine learning and mathematics topics; the papers section lists peer-reviewed work.
+
+## Blog
+- [All posts](https://saattrupdan.com/posts): index of every blog post.
+- [Atom feed](https://saattrupdan.com/atom.xml): subscribe to new posts.
+
+## Research
+- [Papers](https://saattrupdan.com/papers): peer-reviewed research papers with abstracts.
+- [Google Scholar](https://scholar.google.com/citations?user=aNojQDEAAAAJ&hl=en): citation profile.
+- [ORCID](https://orcid.org/0000-0001-9227-1470): research identifier.
+
+## Projects and talks
+- [Projects](https://saattrupdan.com/projects): open-source libraries and tools.
+- [Talks](https://saattrupdan.com/talks): talks, podcasts, and webinars.
+
+## Profiles
+- [GitHub](https://github.com/saattrupdan)
+- [LinkedIn](https://www.linkedin.com/in/saattrupdan/)
+- [CV (PDF)](https://saattrupdan.com/cv.pdf)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,39 @@
+# Default policy
+User-agent: *
+Allow: /
+
+# Explicit allowances for AI search and training crawlers
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+Sitemap: https://saattrupdan.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Add `public/robots.txt` with default Allow plus explicit Allow blocks for AI search/training crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-Web, Claude-SearchBot, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, CCBot) and Sitemap reference.
- Add `public/llms.txt` per llmstxt.org with bio and curated links to Blog, Research (Papers + Scholar + ORCID), Projects, Talks, and profiles (GitHub, LinkedIn, CV).
- Tick Phase 5 in `PLAN.md`.

## Test plan
- [x] `npm run build` succeeds and emits `dist/robots.txt` + `dist/llms.txt`
- [x] Confirm `https://saattrupdan.com/robots.txt` and `/llms.txt` resolve on Vercel preview
- [ ] Spot-check robots.txt with Google's robots tester after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)