### PR TITLE
feat: image alt text and content semantics (SEO phase 6)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -47,11 +47,11 @@ Tracking checklist for the multi-phase SEO/AIO overhaul. Each phase ships as its
 
 ## Phase 6 — Content semantics
 
-- [ ] Change `PostView.vue` post title from `<h2>` to `<h1>`
-- [ ] Audit other views to ensure exactly one `<h1>` each
-- [ ] Add `alt` attribute to author photo in `AboutView.vue`
-- [ ] Audit remaining images for `alt` text
-- [ ] Title pattern: `"<page title> | Dan Saattrup Smart"` (except `/`)
+- [x] Change `PostView.vue` post title from `<h2>` to `<h1>`
+- [x] Audit other views to ensure exactly one `<h1>` each
+- [x] Add `alt` attribute to author photo in `AboutView.vue`
+- [x] Audit remaining images for `alt` text
+- [x] Title pattern: `"<page title> | Dan Saattrup Smart"` (except `/`)
 
 ## Phase 7 — Performance
 

--- a/src/frontend/components/TheFooter.vue
+++ b/src/frontend/components/TheFooter.vue
@@ -16,28 +16,28 @@ const yearRange = year > 2023 ? "2023 - " + year : year;
       <a href="https://github.com/saattrupdan">
         <img
           :src="githubIconUrl"
-          alt="github"
+          alt="GitHub"
           class="footer-icon invert-on-darkmode transition"
         />
       </a>
       <a href="https://www.linkedin.com/in/saattrupdan/">
         <img
           :src="linkedInIconUrl"
-          alt="linkedin"
+          alt="LinkedIn"
           class="footer-icon invert-on-darkmode transition"
         />
       </a>
       <a href="https://scholar.google.com/citations?user=aNojQDEAAAAJ&hl=en">
         <img
           :src="scholarIconUrl"
-          alt="scholar"
+          alt="Google Scholar"
           class="footer-icon invert-on-darkmode transition"
         />
       </a>
       <a href="https://www.saattrupdan.com/atom.xml">
         <img
           :src="rssIconUrl"
-          alt="rss"
+          alt="RSS feed"
           class="footer-icon invert-on-darkmode transition"
         />
       </a>

--- a/src/frontend/views/AboutView.vue
+++ b/src/frontend/views/AboutView.vue
@@ -53,7 +53,7 @@ useHead({
   <div class="container">
     <div class="photo-box">
       <div class="photo-croppable"></div>
-      <img class="photo" :src="photoUrl" />
+      <img class="photo" :src="photoUrl" :alt="`Portrait of ${AUTHOR_NAME}`" />
     </div>
     <div class="description-box">
       <div class="serif-text description">


### PR DESCRIPTION
## Summary
- Add descriptive `alt` to author photo in `AboutView.vue` (\`Portrait of Dan Saattrup Smart\`).
- Improve `alt` text on footer social icons (\`GitHub\`, \`LinkedIn\`, \`Google Scholar\`, \`RSS feed\`).
- Audit confirms exactly one \`<h1>\` per view (PostView already uses \`<h1>\` for the post title; markdown posts use \`##\`/\`###\` only — the lone \`# \` matches were inside fenced code blocks).
- Title pattern \`<page> | Dan Saattrup Smart\` is already enforced via \`App.vue\`'s \`titleTemplate\` (home keeps just \`Dan Saattrup Smart\`).
- Tick Phase 6 in \`PLAN.md\`.

## Test plan
- [x] \`npm run build\` succeeds
- [ ] Spot-check rendered HTML on Vercel preview: AboutView \`<img>\` has alt; footer alts are descriptive
- [ ] Lighthouse accessibility check on \`/\` and a post page

🤖 Generated with [Claude Code](https://claude.com/claude-code)