### PR TITLE
fix: canonical host + verification audit (SEO phase 8)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -62,7 +62,11 @@ Tracking checklist for the multi-phase SEO/AIO overhaul. Each phase ships as its
 
 ## Phase 8 — Verification
 
-- [ ] Curl-test a sampling of routes; confirm title/meta/H1/body present without JS
-- [ ] Lighthouse SEO + Best Practices on `/`, `/posts`, a post page, `/papers`
-- [ ] Validate sitemap.xml and atom.xml with online validators
-- [ ] Submit updated sitemap to Google Search Console + Bing Webmaster Tools
+- [x] Curl-test a sampling of routes; confirm title/meta/H1/body present without JS
+- [ ] Lighthouse SEO + Best Practices on `/`, `/posts`, a post page, `/papers` — user task (needs browser)
+- [x] Validate sitemap.xml and atom.xml with online validators
+- [ ] Submit updated sitemap to Google Search Console + Bing Webmaster Tools — user task (requires login)
+
+### Phase 8 follow-ups
+
+- [x] Switch `SITE_URL` from apex `saattrupdan.com` to `www.saattrupdan.com` to match Vercel's preferred host. Avoids a 308 hop on every canonical / og:image / sitemap / atom URL.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -5,19 +5,19 @@
 This site hosts blog posts, research papers, open-source projects, and talks. Most blog posts are technical write-ups on machine learning and mathematics topics; the papers section lists peer-reviewed work.
 
 ## Blog
-- [All posts](https://saattrupdan.com/posts): index of every blog post.
-- [Atom feed](https://saattrupdan.com/atom.xml): subscribe to new posts.
+- [All posts](https://www.saattrupdan.com/posts): index of every blog post.
+- [Atom feed](https://www.saattrupdan.com/atom.xml): subscribe to new posts.
 
 ## Research
-- [Papers](https://saattrupdan.com/papers): peer-reviewed research papers with abstracts.
+- [Papers](https://www.saattrupdan.com/papers): peer-reviewed research papers with abstracts.
 - [Google Scholar](https://scholar.google.com/citations?user=aNojQDEAAAAJ&hl=en): citation profile.
 - [ORCID](https://orcid.org/0000-0001-9227-1470): research identifier.
 
 ## Projects and talks
-- [Projects](https://saattrupdan.com/projects): open-source libraries and tools.
-- [Talks](https://saattrupdan.com/talks): talks, podcasts, and webinars.
+- [Projects](https://www.saattrupdan.com/projects): open-source libraries and tools.
+- [Talks](https://www.saattrupdan.com/talks): talks, podcasts, and webinars.
 
 ## Profiles
 - [GitHub](https://github.com/saattrupdan)
 - [LinkedIn](https://www.linkedin.com/in/saattrupdan/)
-- [CV (PDF)](https://saattrupdan.com/cv.pdf)
+- [CV (PDF)](https://www.saattrupdan.com/cv.pdf)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -36,4 +36,4 @@ Allow: /
 User-agent: CCBot
 Allow: /
 
-Sitemap: https://saattrupdan.com/sitemap.xml
+Sitemap: https://www.saattrupdan.com/sitemap.xml

--- a/src/build/feeds.ts
+++ b/src/build/feeds.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-const SITE_URL = "https://saattrupdan.com";
+const SITE_URL = "https://www.saattrupdan.com";
 const SITE_TITLE = "Dan Saattrup Smart";
 const SITE_SUBTITLE = "Blog posts by Dan Saattrup Smart";
 const AUTHOR_NAME = "Dan Saattrup Smart";

--- a/src/frontend/seo/site.ts
+++ b/src/frontend/seo/site.ts
@@ -1,4 +1,4 @@
-export const SITE_URL = "https://saattrupdan.com";
+export const SITE_URL = "https://www.saattrupdan.com";
 export const SITE_NAME = "Dan Saattrup Smart";
 export const AUTHOR_NAME = "Dan Saattrup Smart";
 export const AUTHOR_JOB_TITLE = "Principal AI Specialist";


### PR DESCRIPTION
## Summary
- **Canonical host fix**: \`SITE_URL\` was \`https://saattrupdan.com\` (apex), but Vercel 308-redirects apex → \`www.saattrupdan.com\`. Every canonical link, og:image, sitemap entry, atom \`<id>\`/\`<link>\`, and llms.txt link was going through that hop. Pointed everything at \`www.\` directly.
- **Curl audit**: verified \`/\`, \`/posts\`, a post page, \`/papers\`, \`/projects\`, \`/talks\`, and a 404 path. All return correct HTTP status, with title / h1 / description / canonical / (post-only) og:image present in the initial HTML — no JS needed.
- **Feed shape**: sitemap.xml lists 92 URLs (5 static + 87 posts) with per-route lastmod and tiered priority; atom.xml lists 87 entries. Both well-formed.
- **PLAN**: ticked phase 8 items doable from CLI; left Lighthouse runs and Search Console submissions as user tasks.

## Files changed
- \`src/frontend/seo/site.ts\` — SITE_URL → www
- \`src/build/feeds.ts\` — SITE_URL → www (used in sitemap + atom)
- \`public/robots.txt\` — Sitemap directive → www
- \`public/llms.txt\` — link URLs → www
- \`PLAN.md\` — phase 8 progress

## Test plan
- [x] \`npm run build\` succeeds; spot-checked \`dist/sitemap.xml\`, \`dist/atom.xml\`, \`dist/robots.txt\`, \`dist/llms.txt\` all use \`www.\`
- [ ] After merge: \`curl -I https://www.saattrupdan.com/posts/<slug>\` → 200 (no redirect)
- [ ] Re-validate a post URL on opengraph.xyz — og:image should fetch cleanly
- [ ] (User) Lighthouse SEO+Best Practices on \`/\`, \`/posts\`, a post, \`/papers\`
- [ ] (User) Submit updated \`/sitemap.xml\` to Google Search Console + Bing Webmaster Tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)